### PR TITLE
Fixed bug in the drag and drop manager.

### DIFF
--- a/feathers/dragDrop/DragDropManager.hx
+++ b/feathers/dragDrop/DragDropManager.hx
@@ -256,7 +256,7 @@ class DragDropManager
 		{
 			target.globalToLocal(location, location);
 		}
-		if(Std.is(target, DisplayObject))
+		if(target != cast dropTarget)
 		{
 			if(dropTarget != null)
 			{


### PR DESCRIPTION
This line caused some bugs in the drag and drop feature.
Original code: if(target != dropTarget)